### PR TITLE
fix(api): improve error handling for muscles validation

### DIFF
--- a/src/routes/api/muscles/+server.ts
+++ b/src/routes/api/muscles/+server.ts
@@ -19,7 +19,13 @@ export const POST: RequestHandler = async ({ request }) => {
 		const result = v.parse(insertMuscleSchema, json);
 		const created = await insertMuscle(result as Omit<Muscle, 'id'>);
 		return Response.json(created, { status: 201 });
-	} catch (e) {
-		return Response.json(e, { status: 400 });
+	} catch (error) {
+		if (error instanceof v.ValiError) {
+			return Response.json({ error: 'Validation error', issues: error.issues }, { status: 400 });
+		}
+		if (error instanceof Error) {
+			return Response.json({ error: error.message }, { status: 400 });
+		}
+		return Response.json({ error: 'Internal server error' }, { status: 500 });
 	}
 };

--- a/src/routes/api/muscles/[id]/+server.ts
+++ b/src/routes/api/muscles/[id]/+server.ts
@@ -24,8 +24,14 @@ export const PUT: RequestHandler = async ({ request, params }) => {
 		const result = v.parse(updateMuscleSchema, json);
 		await updateMuscle(Number(id), result);
 		return new Response('updated', { status: 200 });
-	} catch (e) {
-		return Response.json(e, { status: 400 });
+	} catch (error) {
+		if (error instanceof v.ValiError) {
+			return Response.json({ error: 'Validation error', issues: error.issues }, { status: 400 });
+		}
+		if (error instanceof Error) {
+			return Response.json({ error: error.message }, { status: 400 });
+		}
+		return Response.json({ error: 'Internal server error' }, { status: 500 });
 	}
 };
 


### PR DESCRIPTION
## Summary
- Add structured error responses for PUT and POST endpoints on muscles API
- Return validation issues from Valibot errors instead of raw error objects
- Distinguish between validation errors (400), general errors (400), and server errors (500)
- Consistent with volume API error handling pattern

## Test plan
- [ ] Test PUT /api/muscles/:id with invalid data - should return structured validation error
- [ ] Test POST /api/muscles with invalid data - should return structured validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)